### PR TITLE
fix: Add fallback providers

### DIFF
--- a/src/contexts/EthereumContext.tsx
+++ b/src/contexts/EthereumContext.tsx
@@ -130,18 +130,27 @@ export function EthereumProvider({ children }: { children: React.ReactNode }) {
 
   // Initialize the provider and listen for account/chain changes
   useEffect(() => {
-    if (window.ethereum) {
-      const provider = new ethers.BrowserProvider(window.ethereum)
+    /*
+     * Check if the Universal Profile extension or regular
+     * wallet injected the related window object
+     */
+    const providerObject = window.lukso || window.ethereum
+
+    // Set global provider
+    if (providerObject) {
+      const provider = new ethers.BrowserProvider(providerObject)
       setProvider(provider)
 
-      window.ethereum.on('accountsChanged', (accounts: string[]) => {
+      providerObject.on('accountsChanged', (accounts: string[]) => {
         setAccount(accounts[0] || null)
       })
 
       // Reload the page when the chain changes
-      window.ethereum.on('chainChanged', () => {
+      providerObject.on('chainChanged', () => {
         window.location.reload()
       })
+    } else {
+      console.log('No wallet extension found')
     }
   }, [])
 

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -3,4 +3,5 @@
  */
 interface Window {
   ethereum: any
+  lukso: any
 }

--- a/src/utils/interfaceDetection.ts
+++ b/src/utils/interfaceDetection.ts
@@ -1,7 +1,15 @@
 import { ethers } from 'ethers'
 import erc165ABI from '../consts/ERC165ABI.json'
 
-const provider = new ethers.BrowserProvider(window.ethereum)
+/*
+ * Initialize base provider to get current blockchain network
+ * The RPC URL can also be passed as string manually, see:
+ * https://docs.lukso.tech/tools/erc725js/getting-started
+ */
+const providerObject = window.lukso || window.ethereum
+const provider = providerObject
+  ? new ethers.BrowserProvider(providerObject)
+  : null
 
 /**
  * Checks if a smart contract has a certain ERC165 interface.
@@ -14,6 +22,10 @@ export async function supportsInterface(
   contractAddress: string,
   interfaceId: string
 ): Promise<boolean> {
+  if (!provider) {
+    console.error('Provider not available.')
+    return false
+  }
   const contract = new ethers.Contract(contractAddress, erc165ABI, provider)
   try {
     return await contract.supportsInterface(interfaceId)

--- a/src/utils/metadataDetection.ts
+++ b/src/utils/metadataDetection.ts
@@ -1,8 +1,15 @@
 import { ethers } from 'ethers'
 import { ERC725 } from '@erc725/erc725.js'
 
-const provider = new ethers.BrowserProvider(window.ethereum)
-
+/*
+ * Initialize base provider to get current blockchain network
+ * The RPC URL can also be passed as string manually, see:
+ * https://docs.lukso.tech/tools/erc725js/getting-started
+ */
+const providerObject = window.lukso || window.ethereum
+const provider = providerObject
+  ? new ethers.BrowserProvider(providerObject)
+  : null
 /**
  * Checks if a smart contract supports a specific ERC725Y data key.
  *
@@ -16,6 +23,10 @@ export async function supportsMetadata(
   schema: any,
   key: string
 ): Promise<boolean> {
+  if (!provider) {
+    console.error('Provider not available.')
+    return false
+  }
   const erc725 = new ERC725(schema, contractAddress, provider, {})
 
   try {


### PR DESCRIPTION
# What does this PR introduce?

This PR introduces **fallback providers** to **fix connection issues** across un-supported browsers of the _Universal Profile Browser Extension_. 

## Previous Behavior

Currently, the repository is using the static `window.ethereum` object to connect to any extension and access the blockchain provider. As the _Universal Profile Browser Extension_ only officially supports `Chrome`, this provider object is not properly injected into other browsers, causing several issues across contexts like showing profile data or switching networks.

## New Behavior

Instead of relying on the `window.ethereum` object, the dApp uses the equivalent `window.lukso`, always available when the _Universal Profile Browser Extension_ is installed. A fallback to the regular `wallet.ethereum` object is implemented, so regular wallets can connect whenever `wallet.lukso` is unavailable.

✅ Successfully tested within `Chrome`, `Opera`, `Firefox`
✅ Verified all functionality on network switches and context updates.
🗃️ Added an internal ticket to resolve the injection issue in future extension releases.  
