### PR TITLE
Improve verification value updates

### DIFF
--- a/src/components/SignInButton/SignInButton.tsx
+++ b/src/components/SignInButton/SignInButton.tsx
@@ -14,7 +14,7 @@ import signInWithEthereum from '@/utils/signInWithEthereum';
  * - useProfile: show profile name once signed in.
  */
 const SignInButton: React.FC = () => {
-  const { account, provider, isVerified, updateAccountInfo } = useEthereum();
+  const { account, provider, isVerified, updateVerification } = useEthereum();
   const { network } = useNetwork();
   const { profile } = useProfile();
 
@@ -43,7 +43,7 @@ const SignInButton: React.FC = () => {
       signInWithEthereum({
         account,
         provider,
-        updateAccountInfo,
+        updateVerification,
         chainId: Number(chainId),
       });
     }

--- a/src/contexts/EthereumContext.tsx
+++ b/src/contexts/EthereumContext.tsx
@@ -86,7 +86,7 @@ const web3OnboardComponent: OnboardAPI = Onboard({
 interface EthereumContextType {
   provider: ethers.BrowserProvider | null;
   account: string | null;
-  updateAccountInfo: (newData: AccountData) => void;
+  updateVerification: (isVerified: boolean) => void;
   connect: () => Promise<void>;
   disconnect: () => void;
   useOnboard: boolean;
@@ -94,10 +94,16 @@ interface EthereumContextType {
   isVerified: boolean; // Check if user is signed in
 }
 
+// Ethereum Context properties
+interface AccountData {
+  account: string | null;
+  isVerified: boolean;
+}
+
 const defaultValue: EthereumContextType = {
   provider: null,
   account: null,
-  updateAccountInfo: () => {},
+  updateVerification: () => {},
   connect: async () => {},
   disconnect: async () => {},
   useOnboard: true,
@@ -203,6 +209,10 @@ export function EthereumProvider({ children }: { children: React.ReactNode }) {
     }
   };
 
+  const updateVerification = async (isVerified: boolean) => {
+    updateAccountInfo({ ...accountData, isVerified: isVerified });
+  };
+
   // Connect to the Ethereum network in the user's extension
   const connect = async () => {
     // If Web3-Onboard is enabled
@@ -258,7 +268,7 @@ export function EthereumProvider({ children }: { children: React.ReactNode }) {
       value={{
         provider,
         account: accountData.account,
-        updateAccountInfo,
+        updateVerification,
         connect,
         disconnect,
         useOnboard,

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -5,9 +5,3 @@ interface Window {
   ethereum: any;
   lukso: any;
 }
-
-// Ethereum Context properties
-interface AccountData {
-  account: string | null;
-  isVerified: boolean;
-}

--- a/src/utils/signInWithEthereum.ts
+++ b/src/utils/signInWithEthereum.ts
@@ -22,12 +22,12 @@ import { EIP_1271_MAGIC_VALUE } from '@/consts/constants';
 const signInWithEthereum = async ({
   account,
   provider,
-  updateAccountInfo,
+  updateVerification,
   chainId,
 }: {
   account: string | null;
   provider: ethers.BrowserProvider | null;
-  updateAccountInfo: (data: AccountData) => void;
+  updateVerification: (isVerified: boolean) => void;
   chainId: number;
 }) => {
   // SIWE requires an connected account of a supported network
@@ -75,10 +75,7 @@ const signInWithEthereum = async ({
     );
 
     // Update global account data
-    updateAccountInfo({
-      account: account,
-      isVerified: isValidSignature === EIP_1271_MAGIC_VALUE,
-    });
+    updateVerification(isValidSignature === EIP_1271_MAGIC_VALUE);
   } catch (error) {
     console.error('Error on signing message: ', error);
   }


### PR DESCRIPTION
The external `signInWithEthereum` function can modify the `account` and `verification` properties of the EthereumContext.

> It should not be possible to update the account address from an external function, only the related `isVerified` property.

I changed the exposed function to only update the `isVerified`.