### PR TITLE
Fix dark mode styling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,14 +9,6 @@
   --lukso-pink: #f6025b;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
-  }
-}
-
 html,
 body {
   height: 100%;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -30,7 +30,6 @@ export default function Home() {
                   <Image
                     src="/lukso_wordmark_black.svg"
                     alt="LUKSO Wordmark"
-                    className="dark:invert"
                     priority
                     fill
                     sizes="100vw"


### PR DESCRIPTION
## Previously on dark mode devices

<img width="1141" alt="Bildschirmfoto 2024-02-01 um 21 05 57" src="https://github.com/lukso-network/tools-dapp-boilerplate/assets/61689369/125781ea-a903-48c9-b3d0-1d8f1a2174e6">


## New default theme

<img width="1141" alt="Bildschirmfoto 2024-02-01 um 21 05 00" src="https://github.com/lukso-network/tools-dapp-boilerplate/assets/61689369/44468295-cb8c-4911-a8aa-7bc9c4db14ae">
