### PR TITLE
Update provider connection during refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ More information is available on our 👉 [technical documentation](https://docs
 - Built-in [`ethers.js`](https://docs.ethers.org/), [`erc725.js`](https://docs.lukso.tech/tools/erc725js/getting-started), [`lsp-smart-contracts`](https://docs.lukso.tech/tools/lsp-smart-contracts/getting-started)
 - Uses `Tailwind`, `Prettier`, `TypeScript`
 
+> **INFO**: You can switch between a regular provider and [Web3-Onboard](https://onboard.blocknative.com/) by setting the `useOnboard` variable within the [EthereumContext](/src/contexts/EthereumContext.tsx).
+
 ## Development
 
 Clone the repository:


### PR DESCRIPTION
## Improvements

1. Upon page reload (F5), the dApp will check for already existing connections and try to:
- `plain-provider`: directly re-establish the connected accounts
- `web3-onboard`: trigger the connection window ([default behavior](https://onboard.blocknative.com/))
- If the user denies the re-connection, the previous account will be removed from local storage

2. Fixes `useCallback` warnings and declaration order of functions called in `useEffect` methods. 